### PR TITLE
ROG-33973 - Allow user to quickly add an email and confirm it without sending real emails

### DIFF
--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -66,7 +66,8 @@ module Users
       if session_email.blank?
         redirect_to add_email_url
       else
-        render :verify, locals: { email: session_email }
+        email_address = EmailAddress.where(user_id: current_user.id).find_with_email(session_email)
+        render :verify, locals: { email: email_address.email, confirmation_token: email_address.confirmation_token }
       end
     end
 

--- a/app/views/accounts/_emails.html.erb
+++ b/app/views/accounts/_emails.html.erb
@@ -15,7 +15,16 @@
             <%= email.email %>
           </span>
           <% unless email.confirmed_at %>
-            &nbsp;<%= t('email_addresses.unconfirmed') %>
+            <% if IdentityConfig.store.dexcom_skip_email_confirmation %>
+              <%
+                # Dexcom Change
+                # This is a shortcut to quickly confirm the email. This is being used for testing
+                # so this is a workaround to avoid sending an email.
+              %>
+              &nbsp;(<%= link_to('Confirm Email',add_email_confirmation_url(confirmation_token: email.confirmation_token, locale: locale_url_param)) %>)
+            <% else %>
+              &nbsp;<%= t('email_addresses.unconfirmed') %>
+            <% end %>
           <% end %>
         </div>
         <% if EmailPolicy.new(current_user).can_delete_email?(email) %>

--- a/app/views/users/emails/verify.html.erb
+++ b/app/views/users/emails/verify.html.erb
@@ -1,5 +1,4 @@
 <% self.title = t('titles.verify_email') %>
-
 <% if @resend_confirmation %>
   <%= render AlertComponent.new(
         type: :success,
@@ -7,30 +6,40 @@
         message: t('notices.resend_confirmation_email.success'),
       ) %>
 <% end %>
-
-<%= render PageHeadingComponent.new.with_content(t('headings.verify_email')) %>
-
-<p><%= t('notices.signed_up_and_confirmed.first_paragraph_start') %>
-   <strong><%= email %></strong>
-   <%= t('notices.signed_up_and_confirmed.first_paragraph_end') %>
-</p>
-
-<div class="width-10">
-  <hr class="margin-y-4 border-width-05 border-info">
-</div>
-
-<%= t('notices.signed_up_and_confirmed.no_email_sent_explanation_start') %>
-<%= button_to(add_email_resend_path, method: :post, class: 'usa-button usa-button--unstyled', form_class: 'display-inline-block padding-left-1') { t('links.resend') } %>
-
-<p><%= t('notices.use_diff_email.text_html', link_html: link_to(t('notices.use_diff_email.link'), add_email_path)) %></p>
-<p><%= t('devise.registrations.close_window') %></p>
-
-<% if FeatureManagement.enable_load_testing_mode? && EmailAddress.find_with_email(email) %>
-  <%= link_to(
+<% if IdentityConfig.store.dexcom_skip_email_confirmation %>
+  <%= render PageHeadingComponent.new.with_content("Click the link below!") %>
+  <%
+  # Dexcom Change:
+  # We are using the add_email_confirmation_url helper to generate the link to verify the email address. Otherwise we have to send an email, and this isn't hooked up to the emailer.
+%>
+  <p>
+    Click the link below to verify your email address: <%= email %>
+  </p>
+  <p>
+    <%= link_to('Confirm Email',add_email_confirmation_url(confirmation_token: confirmation_token, locale: locale_url_param)) %>
+  </p>
+  <div class="width-10">
+    <hr class="margin-y-4 border-width-05 border-info">
+  </div>
+<% else %>
+  <%= render PageHeadingComponent.new.with_content(t('headings.verify_email')) %>
+  <p><%= t('notices.signed_up_and_confirmed.first_paragraph_start') %>
+    <strong><%= email %></strong>
+    <%= t('notices.signed_up_and_confirmed.first_paragraph_end') %>
+  </p>
+  <div class="width-10">
+    <hr class="margin-y-4 border-width-05 border-info">
+  </div>
+  <%= t('notices.signed_up_and_confirmed.no_email_sent_explanation_start') %>
+  <%= button_to(add_email_resend_path, method: :post, class: 'usa-button usa-button--unstyled', form_class: 'display-inline-block padding-left-1') { t('links.resend') } %>
+  <p><%= t('notices.use_diff_email.text_html', link_html: link_to(t('notices.use_diff_email.link'), add_email_path)) %></p>
+  <p><%= t('devise.registrations.close_window') %></p>
+  <% if FeatureManagement.enable_load_testing_mode? && EmailAddress.find_with_email(email) %>
+    <%= link_to(
         'CONFIRM NOW',
         sign_up_create_email_confirmation_url(confirmation_token: EmailAddress.find_with_email(email).confirmation_token),
         id: 'confirm-now',
       ) %>
+  <% end %>
+  <%= link_to t('idv.messages.return_to_profile', app_name: APP_NAME), account_path %>
 <% end %>
-
-<%= link_to t('idv.messages.return_to_profile', app_name: APP_NAME), account_path %>


### PR DESCRIPTION
Problem: We need users to be able to change or add their email to their login.gov to test some features. It requires sending an email to verify it. We don't send emails for our login.gov.

Solution: Immediately give them a link to verify it.

**Step 1:**
![image](https://github.com/user-attachments/assets/44bec412-98fc-4017-84b0-510302b52dd2)

**Step 2:**
![image](https://github.com/user-attachments/assets/e4533ca8-f5a2-4739-87d2-8f32f7e8e8cf)

**Step 3:**
![image](https://github.com/user-attachments/assets/a26bfd22-c85e-4dd4-93fd-3bfb444b3d53)

**Complete:**
![image](https://github.com/user-attachments/assets/bcb155bb-f3a6-48f7-bdcc-d467aefbfdc9)

**How to recreate yourself:**

Run this locally (`make setup` and then `make run`). Go to http://localhost:3000. Login with test1@test.com / `salty pickles`. After that, add an email. It will send a fake email, but ignore that. Our live environment won't do that. Go back to your original page and there will be a link for you.
